### PR TITLE
Add support for gopher-badge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 smoketest: FORCE
 	mkdir -p out
-	tinygo build -o ./out/all.uf2          --target waveshare-rp2040-zero --size short ./games/all/
-	tinygo build -o ./out/flappygopher.uf2 --target waveshare-rp2040-zero --size short ./games/flappygopher/
-	tinygo build -o ./out/jumpingopher.uf2 --target waveshare-rp2040-zero --size short ./games/jumpingopher/
-	tinygo build -o ./out/blocks.uf2       --target waveshare-rp2040-zero --size short ./games/blocks/
+	tinygo build -o ./out/all.zero-kb02.uf2          --target waveshare-rp2040-zero --size short ./games/all/
+	tinygo build -o ./out/flappygopher.zero-kb02.uf2 --target waveshare-rp2040-zero --size short ./games/flappygopher/
+	tinygo build -o ./out/jumpingopher.zero-kb02.uf2 --target waveshare-rp2040-zero --size short ./games/jumpingopher/
+	tinygo build -o ./out/blocks.zero-kb02.uf2       --target waveshare-rp2040-zero --size short ./games/blocks/
+	tinygo build -o ./out/all.gopher-badge.uf2          --target gopher-badge --size short ./games/all/
+	tinygo build -o ./out/flappygopher.gopher-badge.uf2 --target gopher-badge --size short ./games/flappygopher/
+	tinygo build -o ./out/jumpingopher.gopher-badge.uf2 --target gopher-badge --size short ./games/jumpingopher/
+	tinygo build -o ./out/blocks.gopher-badge.uf2       --target gopher-badge --size short ./games/blocks/
 
 FORCE:

--- a/games/blocks/blocks/blocks.go
+++ b/games/blocks/blocks/blocks.go
@@ -320,9 +320,9 @@ func (g *Game) Update() error {
 	}
 
 	// Rotate the block
-	if koebiten.IsKeyJustPressed(koebiten.Key4) || koebiten.IsKeyJustPressed(koebiten.KeyRotaryRight) {
+	if koebiten.IsKeyJustPressed(koebiten.Key4) || koebiten.IsKeyJustPressed(koebiten.KeyRotaryRight) || koebiten.IsKeyJustPressed(koebiten.Key1) {
 		g.rotateTetromino(true)
-	} else if koebiten.IsKeyJustPressed(koebiten.Key8) || koebiten.IsKeyJustPressed(koebiten.KeyRotaryLeft) {
+	} else if koebiten.IsKeyJustPressed(koebiten.Key8) || koebiten.IsKeyJustPressed(koebiten.KeyRotaryLeft) || koebiten.IsKeyJustPressed(koebiten.Key0) {
 		g.rotateTetromino(false)
 	}
 	return nil

--- a/hardware/gopher-badge.go
+++ b/hardware/gopher-badge.go
@@ -1,0 +1,198 @@
+//go:build tinygo && gopher_badge
+
+package hardware
+
+import (
+	"image/color"
+	"machine"
+
+	"github.com/sago35/koebiten"
+	"tinygo.org/x/drivers/pixel"
+	"tinygo.org/x/drivers/st7789"
+)
+
+var Device = &device{}
+
+type device struct {
+	display  *Display
+	gpioPins []machine.Pin
+	state    []State
+	cycle    []int
+}
+
+const (
+	debounce = 0
+)
+
+type State uint8
+
+const (
+	None State = iota
+	NoneToPress
+	Press
+	PressToRelease
+)
+
+func (z *device) Init() error {
+	machine.SPI0.Configure(machine.SPIConfig{
+		Frequency: 8000000,
+		Mode:      0,
+	})
+
+	d := st7789.New(machine.SPI0,
+		machine.TFT_RST,       // TFT_RESET
+		machine.TFT_WRX,       // TFT_DC
+		machine.TFT_CS,        // TFT_CS
+		machine.TFT_BACKLIGHT) // TFT_LITE
+
+	d.Configure(st7789.Config{
+		Rotation: st7789.ROTATION_270,
+		Height:   320,
+	})
+	//d.ClearDisplay()
+	z.display = InitDisplay(&d, 128, 64)
+
+	gpioPins := []machine.Pin{
+		machine.BUTTON_A,
+		machine.BUTTON_B,
+		machine.BUTTON_UP,
+		machine.BUTTON_LEFT,
+		machine.BUTTON_DOWN,
+		machine.BUTTON_RIGHT,
+	}
+
+	for i := range gpioPins {
+		gpioPins[i].Configure(machine.PinConfig{Mode: machine.PinInputPullup})
+	}
+
+	z.gpioPins = []machine.Pin{
+		machine.BUTTON_A,
+		machine.BUTTON_B,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.NoPin,
+		machine.BUTTON_LEFT,
+		machine.BUTTON_RIGHT,
+		machine.BUTTON_UP,
+		machine.BUTTON_DOWN,
+	}
+
+	z.state = make([]State, len(z.gpioPins))
+	z.cycle = make([]int, len(z.gpioPins))
+	return nil
+}
+
+func (z *device) GetDisplay() koebiten.Displayer {
+	return z.display
+}
+
+func (z *device) KeyUpdate() error {
+	for r := range z.gpioPins {
+		current := !z.gpioPins[r].Get()
+		idx := r
+
+		switch z.state[idx] {
+		case None:
+			if current {
+				if z.cycle[idx] >= debounce {
+					z.state[idx] = NoneToPress
+					z.cycle[idx] = 0
+				} else {
+					z.cycle[idx]++
+				}
+			} else {
+				z.cycle[idx] = 0
+			}
+		case NoneToPress:
+			z.state[idx] = Press
+			koebiten.AppendJustPressedKeys([]koebiten.Key{koebiten.Key(idx)})
+		case Press:
+			koebiten.AppendPressedKeys([]koebiten.Key{koebiten.Key(idx)})
+			if current {
+				z.cycle[idx] = 0
+			} else {
+				if z.cycle[idx] >= debounce {
+					z.state[idx] = PressToRelease
+					z.cycle[idx] = 0
+				} else {
+					z.cycle[idx]++
+				}
+			}
+		case PressToRelease:
+			z.state[idx] = None
+			koebiten.AppendJustReleasedKeys([]koebiten.Key{koebiten.Key(idx)})
+		}
+	}
+	return nil
+}
+
+type Display struct {
+	d   *st7789.Device
+	img pixel.Image[pixel.RGB565BE]
+}
+
+func InitDisplay(d *st7789.Device, width, height int) *Display {
+	return &Display{
+		d:   d,
+		img: pixel.NewImage[pixel.RGB565BE](int(width), int(height)),
+	}
+}
+
+func (d *Display) Size() (x, y int16) {
+	return 128, 64
+}
+
+func (d *Display) SetPixel(x, y int16, c color.RGBA) {
+	mx, my := d.img.Size()
+	if 0 <= x && x < int16(mx) && 0 <= y && y < int16(my) {
+		d.img.Set(int(x), int(y), pixelWhite)
+	}
+	return
+	cnt := 0
+	if c.R < 0x80 {
+		cnt++
+	}
+	if c.G < 0x80 {
+		cnt++
+	}
+	if c.B < 0x80 {
+		cnt++
+	}
+	if cnt >= 2 {
+		d.img.Set(int(x), int(y), pixelWhite)
+	} else {
+		d.img.Set(int(x), int(y), pixelBlack)
+	}
+	//d.d.SetPixel(x, y, c)
+}
+
+func (d *Display) Display() error {
+	return d.d.DrawBitmap(0, 0, d.img)
+	//return d.d.Display()
+}
+
+func (d *Display) ClearBuffer() {
+	d.img.FillSolidColor(pixelBlack)
+}
+
+func (d *Display) ClearDisplay() {
+}
+
+var (
+	white = color.RGBA{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF}
+	black = color.RGBA{R: 0x00, G: 0x00, B: 0x00, A: 0xFF}
+
+	pixelWhite = pixel.NewColor[pixel.RGB565BE](0xFF, 0xFF, 0xFF)
+	pixelBlack = pixel.NewColor[pixel.RGB565BE](0x00, 0x00, 0x00)
+)

--- a/hardware/gopher-badge.go
+++ b/hardware/gopher-badge.go
@@ -101,6 +101,9 @@ func (z *device) GetDisplay() koebiten.Displayer {
 func (z *device) KeyUpdate() error {
 	for r := range z.gpioPins {
 		current := !z.gpioPins[r].Get()
+		if z.gpioPins[r] == machine.NoPin {
+			current = false
+		}
 		idx := r
 
 		switch z.state[idx] {

--- a/hardware/zero-kb02.go
+++ b/hardware/zero-kb02.go
@@ -1,4 +1,4 @@
-//go:build tinygo && !macropad_rp2040
+//go:build tinygo && !(macropad_rp2040 || gopher_badge)
 
 package hardware
 


### PR DESCRIPTION
This PR adds gopher-badge support to Koebiten. I believe this change will serve as a reference for creating Koebiten-compatible hardware in the future.
![image](https://github.com/user-attachments/assets/e2583ceb-ae17-4cee-b8ef-ca96da6b1fb8)
