### PR TITLE
Add Image.DrawImage

### DIFF
--- a/examples/GeoM/geom/game.go
+++ b/examples/GeoM/geom/game.go
@@ -20,10 +20,10 @@ const (
 )
 
 type Game struct {
-	x, y int
-
-	scale float64
-	theta float64
+	gopher *koebiten.Image
+	x, y   int
+	scale  float64
+	theta  float64
 }
 
 var (
@@ -33,9 +33,10 @@ var (
 
 func NewGame() *Game {
 	game := &Game{
-		x:     width / 2,
-		y:     height / 2,
-		scale: 1,
+		gopher: koebiten.NewImageFromFS(fsys, "gopher.png"),
+		x:      width / 2,
+		y:      height / 2,
+		scale:  1,
 	}
 	return game
 }
@@ -87,12 +88,12 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (w, h int) {
 }
 
 func (g *Game) Draw(screen *koebiten.Image) {
-	op := koebiten.DrawImageFSOptions{}
+	op := koebiten.DrawImageOptions{}
 	op.GeoM.Translate(-float64(gopherWidth)/2, -float64(gopherHeight)/2)
 	op.GeoM.Scale(g.scale, g.scale)
 	op.GeoM.Rotate(g.theta)
 	op.GeoM.Translate(float64(g.x), float64(g.y))
-	koebiten.DrawImageFSWithOptions(nil, fsys, "gopher.png", op)
+	g.gopher.DrawImage(screen, op)
 }
 
 // isAnyKeyboardKeyPressed returns true if any keyboard key is pressed

--- a/image.go
+++ b/image.go
@@ -28,9 +28,14 @@ func (i *Image) Size() (int16, int16) {
 
 // SetPixel sets the pixel at the given x and y coordinates to the given color.
 // The color is converted to a pixel.Monochrome color.
+// If the x and y coordinates are outside the image, the function does nothing.
 //
 // It implements the Displayer interface.
 func (i *Image) SetPixel(x, y int16, c color.RGBA) {
+	w, h := i.img.Size()
+	if x < 0 || x >= int16(w) || y < 0 || y >= int16(h) {
+		return
+	}
 	i.img.Set(int(x), int(y), pixel.NewMonochrome(c.R, c.G, c.B))
 }
 

--- a/image.go
+++ b/image.go
@@ -1,0 +1,153 @@
+package koebiten
+
+import (
+	"image/color"
+	"io/fs"
+	"math"
+	"reflect"
+
+	"tinygo.org/x/drivers/image/png"
+	"tinygo.org/x/drivers/pixel"
+)
+
+var _ Displayer = (*Image)(nil)
+
+// Image is a Wrapper for the pixel.Image type.
+//
+// Image implements the Displayer interface.
+type Image struct {
+	img *pixel.Image[pixel.Monochrome]
+}
+
+// Size returns the width and height of the image.
+//
+// It implements the Displayer interface.
+func (i *Image) Size() (int16, int16) {
+	x, y := i.img.Size()
+	return int16(x), int16(y)
+}
+
+// SetPixel sets the pixel at the given x and y coordinates to the given color.
+// The color is converted to a pixel.Monochrome color.
+//
+// It implements the Displayer interface.
+func (i *Image) SetPixel(x, y int16, c color.RGBA) {
+	i.img.Set(int(x), int(y), pixel.NewMonochrome(c.R, c.G, c.B))
+}
+
+// Display does nothing.
+//
+// It implements the Displayer interface.
+func (i *Image) Display() error { return nil }
+
+// ClearDisplay clears the display.
+//
+// It implements the Displayer interface.
+func (i *Image) ClearDisplay() {}
+
+// ClearBuffer clears the buffer.
+//
+// It implements the Displayer interface.
+func (i *Image) ClearBuffer() {}
+
+// NewImage creates a new Image with the given width and height.
+//
+// It returns a pointer to the new Image.
+func NewImage(width, height int16) *Image {
+	img := pixel.NewImage[pixel.Monochrome](int(width), int(height))
+	return &Image{
+		img: &img,
+	}
+}
+
+// NewImageFromFS creates a new Image from the filesystem.
+func NewImageFromFS(fsys fs.FS, path string) *Image {
+	img, err := loadImageFromFS(fsys, path)
+	if err != nil {
+		panic(err)
+	}
+	return &Image{img: img}
+}
+
+// loadImageFromFS loads an image from the filesystem.
+func loadImageFromFS(fsys fs.FS, path string) (*pixel.Image[pixel.Monochrome], error) {
+	var buffer [3 * 8 * 8 * 4]uint16
+	p, err := fsys.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var img pixel.Image[pixel.Monochrome]
+	png.SetCallback(buffer[:], func(data []uint16, x, y, w, h, width, height int16) {
+		if img.Len() == 0 {
+			img = pixel.NewImage[pixel.Monochrome](int(width), int(height))
+		}
+
+		for yy := int16(0); yy < h; yy++ {
+			for xx := int16(0); xx < w; xx++ {
+				c := C565toRGBA(data[yy*w+xx])
+				cnt := 0
+				if c.R < 0x80 {
+					cnt++
+				}
+				if c.G < 0x80 {
+					cnt++
+				}
+				if c.B < 0x80 {
+					cnt++
+				}
+				if cnt >= 2 {
+					img.Set(int(x+xx), int(y+yy), true)
+				}
+			}
+		}
+	})
+
+	if _, err = png.Decode(p); err != nil {
+		return nil, err
+	}
+
+	return &img, nil
+}
+
+// Fill fills the image with the given color.
+func (i *Image) Fill(clr color.Color) {
+	r, g, b, _ := clr.RGBA()
+	w, h := i.img.Size()
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			i.img.Set(x, y, pixel.NewMonochrome(uint8(r), uint8(g), uint8(b)))
+		}
+	}
+}
+
+type DrawImageOptions struct {
+	GeoM GeoM
+}
+
+// DrawImage draws an image onto the display.
+func (i *Image) DrawImage(dst Displayer, options DrawImageOptions) {
+	if isNil(dst) {
+		dst = display
+	}
+
+	geoM := options.GeoM
+	if !geoM.IsInvertible() {
+		return
+	}
+
+	w, h := i.img.Size()
+	dw, dh := dst.Size()
+	for yy := 0; yy < min(h, int(dh)); yy++ {
+		for xx := 0; xx < min(w, int(dw)); xx++ {
+			if i.img.Get(xx, yy) == true {
+				xxf, yyf := geoM.Apply(float64(xx), float64(yy))
+				dst.SetPixel(int16(math.Round(float64(xxf))), int16(math.Round(float64(yyf))), white)
+			}
+		}
+	}
+}
+
+func isNil(d Displayer) bool {
+	return d == nil || (reflect.ValueOf(d).Kind() == reflect.Ptr && reflect.ValueOf(d).IsNil())
+}

--- a/image.go
+++ b/image.go
@@ -4,7 +4,6 @@ import (
 	"image/color"
 	"io/fs"
 	"math"
-	"reflect"
 
 	"tinygo.org/x/drivers/image/png"
 	"tinygo.org/x/drivers/pixel"
@@ -145,8 +144,4 @@ func (i *Image) DrawImage(dst Displayer, options DrawImageOptions) {
 			}
 		}
 	}
-}
-
-func isNil(d Displayer) bool {
-	return d == nil || (reflect.ValueOf(d).Kind() == reflect.Ptr && reflect.ValueOf(d).IsNil())
 }

--- a/image.go
+++ b/image.go
@@ -16,7 +16,7 @@ var _ Displayer = (*Image)(nil)
 //
 // Image implements the Displayer interface.
 type Image struct {
-	img *pixel.Image[pixel.Monochrome]
+	img pixel.Image[pixel.Monochrome]
 }
 
 // Size returns the width and height of the image.
@@ -54,9 +54,8 @@ func (i *Image) ClearBuffer() {}
 //
 // It returns a pointer to the new Image.
 func NewImage(width, height int16) *Image {
-	img := pixel.NewImage[pixel.Monochrome](int(width), int(height))
 	return &Image{
-		img: &img,
+		img: pixel.NewImage[pixel.Monochrome](int(width), int(height)),
 	}
 }
 
@@ -70,11 +69,11 @@ func NewImageFromFS(fsys fs.FS, path string) *Image {
 }
 
 // loadImageFromFS loads an image from the filesystem.
-func loadImageFromFS(fsys fs.FS, path string) (*pixel.Image[pixel.Monochrome], error) {
+func loadImageFromFS(fsys fs.FS, path string) (pixel.Image[pixel.Monochrome], error) {
 	var buffer [3 * 8 * 8 * 4]uint16
 	p, err := fsys.Open(path)
 	if err != nil {
-		return nil, err
+		return pixel.Image[pixel.Monochrome]{}, err
 	}
 
 	var img pixel.Image[pixel.Monochrome]
@@ -104,10 +103,10 @@ func loadImageFromFS(fsys fs.FS, path string) (*pixel.Image[pixel.Monochrome], e
 	})
 
 	if _, err = png.Decode(p); err != nil {
-		return nil, err
+		return pixel.Image[pixel.Monochrome]{}, err
 	}
 
-	return &img, nil
+	return img, nil
 }
 
 // Fill fills the image with the given color.

--- a/koebiten.go
+++ b/koebiten.go
@@ -8,7 +8,6 @@ import (
 	"image/color"
 	"io/fs"
 	"math"
-	"reflect"
 	"strings"
 	"time"
 
@@ -18,26 +17,6 @@ import (
 	"tinygo.org/x/tinydraw"
 	"tinygo.org/x/tinyfont"
 )
-
-type Image struct {
-}
-
-func (i *Image) Size() (x, y int16) {
-	return 0, 0
-}
-
-func (i *Image) SetPixel(x, y int16, c color.RGBA) {
-}
-
-func (i *Image) Display() error {
-	return nil
-}
-
-func (i *Image) ClearDisplay() {
-}
-
-func (i *Image) ClearBuffer() {
-}
 
 // Displayer interface for display operations.
 type Displayer interface {
@@ -281,9 +260,7 @@ func DrawImageFSWithOptions(dst Displayer, fsys fs.FS, path string, options Draw
 	}
 
 	geoM := options.GeoM
-	a, b, c, d, tx, ty := geoM.elements32()
-	det := a*d - b*c
-	if det == 0 {
+	if !geoM.IsInvertible() {
 		return
 	}
 
@@ -291,12 +268,9 @@ func DrawImageFSWithOptions(dst Displayer, fsys fs.FS, path string, options Draw
 	for yy := 0; yy < h; yy++ {
 		for xx := 0; xx < w; xx++ {
 			if img.Get(xx, yy) == true {
-				dst.SetPixel(int16(math.Round(float64(a*float32(xx)+b*float32(yy)+tx))), int16(math.Round(float64(c*float32(xx)+d*float32(yy)+ty))), white)
+				xxf, yyf := geoM.Apply(float64(xx), float64(yy))
+				dst.SetPixel(int16(math.Round(float64(xxf))), int16(math.Round(float64(yyf))), white)
 			}
 		}
 	}
-}
-
-func isNil(d Displayer) bool {
-	return d == nil || (reflect.ValueOf(d).Kind() == reflect.Ptr && reflect.ValueOf(d).IsNil())
 }

--- a/koebiten.go
+++ b/koebiten.go
@@ -8,6 +8,7 @@ import (
 	"image/color"
 	"io/fs"
 	"math"
+	"reflect"
 	"strings"
 	"time"
 
@@ -209,6 +210,8 @@ type DrawImageFSOptions struct {
 }
 
 // DrawImageFS draws an image from the filesystem onto the display.
+//
+// Deprecated: Use Image and Image.DrawImage instead.
 func DrawImageFS(dst Displayer, fsys fs.FS, path string, x, y int) {
 	op := DrawImageFSOptions{}
 	op.GeoM.Translate(float64(x), float64(y))
@@ -216,6 +219,8 @@ func DrawImageFS(dst Displayer, fsys fs.FS, path string, x, y int) {
 }
 
 // DrawImageFSWithOptions draws an image from the filesystem onto the display with options.
+//
+// Deprecated: Use Image and Image.DrawImage instead.
 func DrawImageFSWithOptions(dst Displayer, fsys fs.FS, path string, options DrawImageFSOptions) {
 	if isNil(dst) {
 		dst = display
@@ -273,4 +278,8 @@ func DrawImageFSWithOptions(dst Displayer, fsys fs.FS, path string, options Draw
 			}
 		}
 	}
+}
+
+func isNil(d Displayer) bool {
+	return d == nil || (reflect.ValueOf(d).Kind() == reflect.Ptr && reflect.ValueOf(d).IsNil())
 }


### PR DESCRIPTION
This PR adds functionality equivalent to ebitengine's Image.DrawImage.
Replace `DrawImageFS` with `Image.DrawImage`.

- https://github.com/hajimehoshi/ebiten/blob/main/image.go