### PR TITLE
Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ If the hardware you're adding is not a simple, off-the-shelf product like zero-k
 you'll need a build tag such as `go:build zero_kb02`.
 For more details, see [#8](https://github.com/sago35/koebiten/pull/8).
 
+## Tags
+
+### koebiten\_benchmark
+
+If you specify the **`koebiten_benchmark`** tag, it will display the time taken to render **32 frames** every **32 frames** in **microseconds (us)**.
+If the processing is light enough, the displayed value should be around **1024us**. 
+If this value becomes significantly larger, it indicates that the frame rate is unstable.
+
+```
+$ tinygo flash --target ./targets/zero-kb02.json --size short --tags koebiten_benchmark ./games/flappygopher
+```
+
 ## link
 
 * https://ebitengine.org/

--- a/bench.go
+++ b/bench.go
@@ -1,0 +1,7 @@
+//go:build koebiten_benchmark
+
+package koebiten
+
+func init() {
+	enableBenchmark = true
+}

--- a/koebiten.go
+++ b/koebiten.go
@@ -29,7 +29,9 @@ type Displayer interface {
 var (
 	display Displayer
 
-	textY int16
+	textY           int16
+	ticks           uint32
+	enableBenchmark bool
 )
 
 var (
@@ -50,8 +52,16 @@ func Run(d func()) error {
 
 func RunGame(game Game) error {
 	tick := time.Tick(32 * time.Millisecond)
+	s := time.Now().UnixMicro()
 	for {
 		<-tick
+		ticks++
+		if enableBenchmark && (ticks%32) == 0 {
+			// print per 32 frame
+			fmt.Printf("debug: %d us / 32 frames\n", int(time.Now().UnixMicro()-s))
+			s = time.Now().UnixMicro()
+		}
+
 		keyUpdate()
 		theInputState.update()
 		textY = 0

--- a/koebiten.go
+++ b/koebiten.go
@@ -45,17 +45,7 @@ func init() {
 
 // Run starts the main loop for the application.
 func Run(d func()) error {
-	tick := time.Tick(32 * time.Millisecond)
-	for {
-		<-tick
-		keyUpdate()
-		theInputState.update()
-		textY = 0
-		display.ClearBuffer()
-		d()
-		display.Display()
-	}
-	return nil
+	return RunGame(dummyGame(d))
 }
 
 func RunGame(game Game) error {

--- a/util.go
+++ b/util.go
@@ -57,3 +57,18 @@ const (
 	Rotation180
 	Rotation270
 )
+
+// dummyGame is a type that represents a simple game function.
+type dummyGame func()
+
+func (g dummyGame) Update() error {
+	return nil
+}
+
+func (g dummyGame) Draw(*Image) {
+	g()
+}
+
+func (g dummyGame) Layout(int, int) (int, int) {
+	return 128, 64
+}


### PR DESCRIPTION
By setting the **`koebiten_benchmark`** tag, the time taken for **32 draw calls** over **32 frames** will be displayed.  

This allows you to check for any **frame drops**.  

To use it, specify `--tags koebiten_benchmark`.