### PR TITLE
Change from float64 to float32 for performance

### DIFF
--- a/examples/GeoM/geom/game.go
+++ b/examples/GeoM/geom/game.go
@@ -22,8 +22,8 @@ const (
 type Game struct {
 	gopher *koebiten.Image
 	x, y   int
-	scale  float64
-	theta  float64
+	scale  float32
+	theta  float32
 }
 
 var (
@@ -89,10 +89,10 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (w, h int) {
 
 func (g *Game) Draw(screen *koebiten.Image) {
 	op := koebiten.DrawImageOptions{}
-	op.GeoM.Translate(-float64(gopherWidth)/2, -float64(gopherHeight)/2)
+	op.GeoM.Translate(-float32(gopherWidth)/2, -float32(gopherHeight)/2)
 	op.GeoM.Scale(g.scale, g.scale)
 	op.GeoM.Rotate(g.theta)
-	op.GeoM.Translate(float64(g.x), float64(g.y))
+	op.GeoM.Translate(float32(g.x), float32(g.y))
 	g.gopher.DrawImage(screen, op)
 }
 

--- a/examples/GeoM/geom/game.go
+++ b/examples/GeoM/geom/game.go
@@ -43,8 +43,8 @@ func NewGame() *Game {
 
 // Game update process
 func (g *Game) Update() error {
-	ds := 0.05
-	dt := 0.2
+	ds := float32(0.05)
+	dt := float32(0.2)
 	dx := 1
 	dy := 1
 

--- a/games/flappygopher/flappygopher/game.go
+++ b/games/flappygopher/flappygopher/game.go
@@ -39,11 +39,11 @@ type wall struct {
 }
 
 var (
-	x    = 20.0
-	y    = 30.0
-	vy   = 0.0  // Velocity of y (速度のy成分) の略
-	g    = 0.05 // Gravity (重力加速度) の略
-	jump = -1.0 // ジャンプ力
+	x    = float32(20.0)
+	y    = float32(30.0)
+	vy   = float32(0.0)  // Velocity of y (速度のy成分) の略
+	g    = float32(0.05) // Gravity (重力加速度) の略
+	jump = float32(-1.0) // ジャンプ力
 
 	frames     = 0         // 経過フレーム数
 	interval   = 120       // 壁の追加間隔

--- a/games/jumpingopher/jumpingopher/game.go
+++ b/games/jumpingopher/jumpingopher/game.go
@@ -145,7 +145,7 @@ func drawWalls(c *cloud) {
 	koebiten.DrawImageFS(nil, fsys, "cloud.png", c.cloudX, c.holeY-cloudHeight)
 }
 
-func walkGopher(x, y float64, frames int) {
+func walkGopher(x, y float32, frames int) {
 	img := "gopher.png"
 	if frames%2 != 0 {
 		img = "gopher_r.png"

--- a/games/jumpingopher/jumpingopher/game.go
+++ b/games/jumpingopher/jumpingopher/game.go
@@ -42,11 +42,11 @@ type platform struct {
 }
 
 var (
-	x            = 50.0
-	y            = 30.0
-	vy           = 0.0
-	g            = 0.05
-	jump         = -1.0
+	x            = float32(50.0)
+	y            = float32(30.0)
+	vy           = float32(0.0)
+	g            = float32(0.05)
+	jump         = float32(-1.0)
 	frames       = 30
 	interval     = 120
 	cloudStartX  = 200

--- a/games/snakegame/snakegame/snakegame.go
+++ b/games/snakegame/snakegame/snakegame.go
@@ -131,7 +131,7 @@ func (g *Game) Update() error {
 	if next == g.food {
 		g.spawnFood()
 		g.score = len(g.snake) - 1
-		g.speed = time.Duration(float64(g.speed) * 0.95)
+		g.speed = time.Duration(float32(g.speed) * 0.95)
 	} else {
 		g.snake = g.snake[:len(g.snake)-1]
 	}

--- a/geom.go
+++ b/geom.go
@@ -16,7 +16,8 @@ package koebiten
 
 import (
 	"fmt"
-	"math"
+
+	"github.com/chewxy/math32"
 )
 
 // GeoMDim is a dimension of a GeoM.
@@ -26,12 +27,12 @@ const GeoMDim = 3
 //
 // The initial value is identity.
 type GeoM struct {
-	a_1 float64 // The actual 'a' value minus 1
-	b   float64
-	c   float64
-	d_1 float64 // The actual 'd' value minus 1
-	tx  float64
-	ty  float64
+	a_1 float32 // The actual 'a' value minus 1
+	b   float32
+	c   float32
+	d_1 float32 // The actual 'd' value minus 1
+	tx  float32
+	ty  float32
 }
 
 // String returns a string representation of GeoM.
@@ -52,7 +53,7 @@ func (g *GeoM) Reset() {
 // Apply pre-multiplies a vector (x, y, 1) by the matrix.
 // In other words, Apply calculates GeoM * (x, y, 1)^T.
 // The return value is x and y values of the result vector.
-func (g *GeoM) Apply(x, y float64) (float64, float64) {
+func (g *GeoM) Apply(x, y float32) (float32, float32) {
 	return (g.a_1+1)*x + g.b*y + g.tx, g.c*x + (g.d_1+1)*y + g.ty
 }
 
@@ -61,7 +62,7 @@ func (g *GeoM) elements32() (a, b, c, d, tx, ty float32) {
 }
 
 // Element returns a value of a matrix at (i, j).
-func (g *GeoM) Element(i, j int) float64 {
+func (g *GeoM) Element(i, j int) float32 {
 	switch {
 	case i == 0 && j == 0:
 		return g.a_1 + 1
@@ -99,7 +100,7 @@ func (g *GeoM) Concat(other GeoM) {
 }
 
 // Scale scales the matrix by (x, y).
-func (g *GeoM) Scale(x, y float64) {
+func (g *GeoM) Scale(x, y float32) {
 	a := (g.a_1 + 1) * x
 	b := g.b * x
 	tx := g.tx * x
@@ -116,19 +117,19 @@ func (g *GeoM) Scale(x, y float64) {
 }
 
 // Translate translates the matrix by (tx, ty).
-func (g *GeoM) Translate(tx, ty float64) {
+func (g *GeoM) Translate(tx, ty float32) {
 	g.tx += tx
 	g.ty += ty
 }
 
 // Rotate rotates the matrix clockwise by theta.
 // The unit is radian.
-func (g *GeoM) Rotate(theta float64) {
+func (g *GeoM) Rotate(theta float32) {
 	if theta == 0 {
 		return
 	}
 
-	sin, cos := math.Sincos(theta)
+	sin, cos := math32.Sincos(theta)
 
 	a := cos*(g.a_1+1) - sin*g.c
 	b := cos*g.b - sin*(g.d_1+1)
@@ -146,9 +147,9 @@ func (g *GeoM) Rotate(theta float64) {
 }
 
 // Skew skews the matrix by (skewX, skewY). The unit is radian.
-func (g *GeoM) Skew(skewX, skewY float64) {
-	sx := math.Tan(skewX)
-	sy := math.Tan(skewY)
+func (g *GeoM) Skew(skewX, skewY float32) {
+	sx := math32.Tan(skewX)
+	sy := math32.Tan(skewY)
 
 	a := (g.a_1 + 1) + g.c*sx
 	b := g.b + (g.d_1+1)*sx
@@ -165,7 +166,7 @@ func (g *GeoM) Skew(skewX, skewY float64) {
 	g.ty = ty
 }
 
-func (g *GeoM) det2x2() float64 {
+func (g *GeoM) det2x2() float32 {
 	return (g.a_1+1)*(g.d_1+1) - g.b*g.c
 }
 
@@ -199,7 +200,7 @@ func (g *GeoM) Invert() {
 }
 
 // SetElement sets an element at (i, j).
-func (g *GeoM) SetElement(i, j int, element float64) {
+func (g *GeoM) SetElement(i, j int, element float32) {
 	e := element
 	switch {
 	case i == 0 && j == 0:

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	tinygo.org/x/tinyfont v0.5.0
 )
 
-require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+require (
+	github.com/chewxy/math32 v1.11.1 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/chewxy/math32 v1.11.1 h1:b7PGHlp8KjylDoU8RrcEsRuGZhJuz8haxnKfuMMRqy8=
+github.com/chewxy/math32 v1.11.1/go.mod h1:dOB2rcuFrCn6UHrze36WSLVPKtzPMRAQvBvUwkSsLqs=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 tinygo.org/x/drivers v0.29.0 h1:xHuq8Fr1D/D2+1V/3d+aXufqP81/CLi1itdVbrYgrE0=

--- a/image.go
+++ b/image.go
@@ -3,8 +3,8 @@ package koebiten
 import (
 	"image/color"
 	"io/fs"
-	"math"
 
+	"github.com/chewxy/math32"
 	"tinygo.org/x/drivers/image/png"
 	"tinygo.org/x/drivers/pixel"
 )
@@ -144,8 +144,8 @@ func (i *Image) DrawImage(dst Displayer, options DrawImageOptions) {
 	for yy := 0; yy < min(h, int(dh)); yy++ {
 		for xx := 0; xx < min(w, int(dw)); xx++ {
 			if i.img.Get(xx, yy) == true {
-				xxf, yyf := geoM.Apply(float64(xx), float64(yy))
-				dst.SetPixel(int16(math.Round(float64(xxf))), int16(math.Round(float64(yyf))), white)
+				xxf, yyf := geoM.Apply(float32(xx), float32(yy))
+				dst.SetPixel(int16(math32.Round(xxf)), int16(math32.Round(yyf)), white)
 			}
 		}
 	}

--- a/koebiten.go
+++ b/koebiten.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"image/color"
 	"io/fs"
-	"math"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/chewxy/math32"
 	"tinygo.org/x/drivers"
 	"tinygo.org/x/drivers/image/png"
 	"tinygo.org/x/drivers/pixel"
@@ -214,7 +214,7 @@ type DrawImageFSOptions struct {
 // Deprecated: Use Image and Image.DrawImage instead.
 func DrawImageFS(dst Displayer, fsys fs.FS, path string, x, y int) {
 	op := DrawImageFSOptions{}
-	op.GeoM.Translate(float64(x), float64(y))
+	op.GeoM.Translate(float32(x), float32(y))
 	DrawImageFSWithOptions(dst, fsys, path, op)
 }
 
@@ -273,8 +273,8 @@ func DrawImageFSWithOptions(dst Displayer, fsys fs.FS, path string, options Draw
 	for yy := 0; yy < h; yy++ {
 		for xx := 0; xx < w; xx++ {
 			if img.Get(xx, yy) == true {
-				xxf, yyf := geoM.Apply(float64(xx), float64(yy))
-				dst.SetPixel(int16(math.Round(float64(xxf))), int16(math.Round(float64(yyf))), white)
+				xxf, yyf := geoM.Apply(float32(xx), float32(yy))
+				dst.SetPixel(int16(math32.Round(xxf)), int16(math32.Round(yyf)), white)
 			}
 		}
 	}


### PR DESCRIPTION
Due to **#16**, `DrawImageFromFS` has become slower. In the **flappygopher** example mentioned later, the frame rate has noticeably worsened.  

This PR aims for a slight performance improvement by using **`float32`** instead of **`float64`**.