### PR TITLE
Reduce geoM.Apply() call for performance improvement

### DIFF
--- a/image.go
+++ b/image.go
@@ -140,12 +140,23 @@ func (i *Image) DrawImage(dst Displayer, options DrawImageOptions) {
 	}
 
 	w, h := i.img.Size()
-	dw, dh := dst.Size()
-	for yy := 0; yy < min(h, int(dh)); yy++ {
-		for xx := 0; xx < min(w, int(dw)); xx++ {
-			if i.img.Get(xx, yy) == true {
-				xxf, yyf := geoM.Apply(float32(xx), float32(yy))
-				dst.SetPixel(int16(math32.Round(xxf)), int16(math32.Round(yyf)), white)
+	if geoM.a_1 == 0 && geoM.b == 0 && geoM.c == 0 && geoM.d_1 == 0 {
+		tx, ty := geoM.Apply(0, 0)
+		ox, oy := int(math32.Round(tx)), int(math32.Round(ty))
+		for yy := 0; yy < h; yy++ {
+			for xx := 0; xx < w; xx++ {
+				if i.img.Get(xx, yy) == true {
+					dst.SetPixel(int16(xx+ox), int16(yy+oy), white)
+				}
+			}
+		}
+	} else {
+		for yy := 0; yy < h; yy++ {
+			for xx := 0; xx < w; xx++ {
+				if i.img.Get(xx, yy) == true {
+					xxf, yyf := geoM.Apply(float32(xx), float32(yy))
+					dst.SetPixel(int16(math32.Round(xxf)), int16(math32.Round(yyf)), white)
+				}
 			}
 		}
 	}

--- a/koebiten.go
+++ b/koebiten.go
@@ -270,11 +270,23 @@ func DrawImageFSWithOptions(dst Displayer, fsys fs.FS, path string, options Draw
 	}
 
 	w, h := img.Size()
-	for yy := 0; yy < h; yy++ {
-		for xx := 0; xx < w; xx++ {
-			if img.Get(xx, yy) == true {
-				xxf, yyf := geoM.Apply(float32(xx), float32(yy))
-				dst.SetPixel(int16(math32.Round(xxf)), int16(math32.Round(yyf)), white)
+	if geoM.a_1 == 0 && geoM.b == 0 && geoM.c == 0 && geoM.d_1 == 0 {
+		tx, ty := geoM.Apply(0, 0)
+		ox, oy := int(math32.Round(tx)), int(math32.Round(ty))
+		for yy := 0; yy < h; yy++ {
+			for xx := 0; xx < w; xx++ {
+				if img.Get(xx, yy) == true {
+					dst.SetPixel(int16(xx+ox), int16(yy+oy), white)
+				}
+			}
+		}
+	} else {
+		for yy := 0; yy < h; yy++ {
+			for xx := 0; xx < w; xx++ {
+				if img.Get(xx, yy) == true {
+					xxf, yyf := geoM.Apply(float32(xx), float32(yy))
+					dst.SetPixel(int16(math32.Round(xxf)), int16(math32.Round(yyf)), white)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
With this change, the frame rate, which had significantly degraded at **score 4** before the modification, is now **much improved even at score 20**.

```
# before (score 4)
debug: 1876520 us / 32 frames
```

```
# after (score 20 !!)
debug: 1248168 us / 32 frames
```