### PR TITLE
Improve performance of Wasm

### DIFF
--- a/hardware/wasm.go
+++ b/hardware/wasm.go
@@ -55,14 +55,19 @@ func wasmKeyEvent() js.Func {
 
 func NewDisplay(w, h int) *Display {
 	return &Display{
-		w: int16(w),
-		h: int16(h),
+		w:   int16(w),
+		h:   int16(h),
+		buf: make([]byte, w*h*4),
 	}
 }
 
 type Display struct {
-	w int16
-	h int16
+	w   int16
+	h   int16
+	buf []byte // RGBA framebuffer, transferred to JS in one call per frame
+
+	jsBuf     js.Value // window.screenBuffer (Uint8Array)
+	jsDisplay js.Value // window.display
 }
 
 func (d *Display) Size() (x, y int16) {
@@ -70,20 +75,31 @@ func (d *Display) Size() (x, y int16) {
 }
 
 func (d *Display) SetPixel(x, y int16, c color.RGBA) {
-	js.Global().Call("setPixel", x, y, c.R, c.G, c.B, c.A)
+	if x < 0 || x >= d.w || y < 0 || y >= d.h {
+		return
+	}
+	i := (int(y)*int(d.w) + int(x)) * 4
+	d.buf[i] = c.R
+	d.buf[i+1] = c.G
+	d.buf[i+2] = c.B
+	d.buf[i+3] = c.A
 }
 
 func (d *Display) Display() error {
-	js.Global().Call("display")
+	js.CopyBytesToJS(d.jsBuf, d.buf)
+	d.jsDisplay.Invoke()
 	return nil
 }
 
 func (d *Display) ClearDisplay() {
-	js.Global().Call("clearScreen")
+	d.ClearBuffer()
+	d.Display()
 }
 
 func (d *Display) ClearBuffer() {
-	js.Global().Call("clearScreen")
+	for i := range d.buf {
+		d.buf[i] = 0
+	}
 }
 
 type WasmDevice struct {
@@ -94,6 +110,9 @@ func (w *WasmDevice) GetDisplay() koebiten.Displayer {
 }
 
 func (w *WasmDevice) Init() error {
+	g := js.Global()
+	d.jsBuf = g.Get("screenBuffer")
+	d.jsDisplay = g.Get("display")
 	return nil
 }
 

--- a/static/main.js
+++ b/static/main.js
@@ -44,12 +44,31 @@ screen.canvas.addEventListener("touchstart", (event) => {
     }
 });
 
+// Go 側から js.CopyBytesToJS で 1 フレーム分を一括転送するためのバッファ
+window.screenBuffer = screen.buffer;
+
+// 旧 API との互換用（現在の Go 側からは呼ばれない）
 window.setPixel = (x, y, r, g, b, a) => {
-    screen.setPixel(x, y, { r, g, b, a });
+    screen.setPixel(x, y, r, g, b, a);
 };
+
+// URL に ?perf を付けると FPS を console に出力する
+const perfEnabled = new URLSearchParams(location.search).has("perf");
+let perfFrames = 0;
+let perfLast = performance.now();
 
 window.display = () => {
     screen.display();
+
+    if (perfEnabled) {
+        perfFrames++;
+        const now = performance.now();
+        if (now - perfLast >= 1000) {
+            console.log(`fps: ${(perfFrames * 1000 / (now - perfLast)).toFixed(1)}`);
+            perfFrames = 0;
+            perfLast = now;
+        }
+    }
 };
 
 window.clearScreen = () => {

--- a/static/screen-emulator.js
+++ b/static/screen-emulator.js
@@ -3,7 +3,7 @@ export default class ScreenEmulator {
         this.width = width;
         this.height = height;
         this.scale = scale;
-        this.buffer = new Uint32Array(width * height); // RGBA 格納用
+        this.buffer = new Uint8Array(width * height * 4); // RGBA 格納用(Go 側から一括転送される)
 
         // 外枠用の div を作成
         this.container = document.createElement("div");
@@ -22,6 +22,13 @@ export default class ScreenEmulator {
         this.ctx.imageSmoothingEnabled = false; // ピクセルを綺麗に保つ
         this.canvas.style.display = "block";
 
+        // 等倍描画用のオフスクリーンキャンバスと ImageData は 1 回だけ生成して再利用する
+        this.offscreen = document.createElement("canvas");
+        this.offscreen.width = width;
+        this.offscreen.height = height;
+        this.offCtx = this.offscreen.getContext("2d");
+        this.imageData = this.offCtx.createImageData(width, height);
+
         // DOM に追加
         this.container.appendChild(this.canvas);
     }
@@ -30,28 +37,21 @@ export default class ScreenEmulator {
         return { x: this.width, y: this.height };
     }
 
-    setPixel(x, y, { r, g, b, a }) {
+    setPixel(x, y, r, g, b, a) {
         if (x < 0 || x >= this.width || y < 0 || y >= this.height) return;
-        const index = y * this.width + x;
-        this.buffer[index] = (a << 24) | (r << 16) | (g << 8) | b;
+        const i = (y * this.width + x) * 4;
+        this.buffer[i] = r;
+        this.buffer[i + 1] = g;
+        this.buffer[i + 2] = b;
+        this.buffer[i + 3] = a;
     }
 
     display() {
-        const imageData = this.ctx.createImageData(this.width, this.height);
-        const data = new Uint32Array(imageData.data.buffer);
+        this.imageData.data.set(this.buffer);
+        this.offCtx.putImageData(this.imageData, 0, 0);
 
-        for (let i = 0; i < this.buffer.length; i++) {
-            data[i] = this.buffer[i];
-        }
-
-        // 小さいキャンバスに描画し、拡大して表示
-        const tempCanvas = document.createElement("canvas");
-        tempCanvas.width = this.width;
-        tempCanvas.height = this.height;
-        const tempCtx = tempCanvas.getContext("2d");
-        tempCtx.putImageData(imageData, 0, 0);
-
+        // 小さいキャンバスに描画した内容を拡大して表示
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        this.ctx.drawImage(tempCanvas, 0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.drawImage(this.offscreen, 0, 0, this.canvas.width, this.canvas.height);
     }
 }


### PR DESCRIPTION
This PR improves performance by eliminating the overhead between JavaScript and WebAssembly on every SetPixel call. Specifically, the load in FlappyGopher, which was about 30%, has been reduced to about 5%.